### PR TITLE
Fix: enable aliases

### DIFF
--- a/Week4/emojize.py
+++ b/Week4/emojize.py
@@ -1,3 +1,3 @@
 from emoji import emojize
 
-print("Output:", emojize(input("Input: ")))
+print("Output:", emojize(input("Input: "), language="alias"))


### PR DESCRIPTION
In Emojize in Problem Set 4, ":smile_cat:" in the test sample is an alias for ":grinning_cat_with_smiling_eyes:".
This causes the program to output ":smile_cat:" instead of 😸 when ":smile_cat:" is entered.
There is no alias in the check input though, doing emojize(language='alias') enables both the full list and aliases.