### PR TITLE
Fix TypeError when multipling by current_price if API returns string

### DIFF
--- a/Week4/bitcoin.py
+++ b/Week4/bitcoin.py
@@ -4,7 +4,7 @@ import requests
 try:
     response = requests.get("https://api.coindesk.com/v1/bpi/currentprice.json")
     data = response.json()
-    current_price = data["bpi"]["USD"]["rate_float"]
+    current_price = float(data["bpi"]["USD"]["rate_float"]) 
 except requests.RequestException:
     sys.exit()
 


### PR DESCRIPTION
###I wrapped 'current_price = data["bpi"]["USD"]["rate_float"]' with 'float(...).
This ensure that this code will not show: TypeError: can't multiply sequence by non-int of type 'float' .